### PR TITLE
Change redhat-access-insights to insights-client

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-redhat-access-insights-client
+redhat-insights-client
 ========
 
-Installs, configures, and registers a system to the [Red Hat Insights service](http://access.redhat.com/insights).  This role is intended to work on RHEL 6 or RHEL 7, though it will generally work on any yum based system that has access to the redhat-access-insights RPM.
+Installs, configures, and registers a system to the [Red Hat Insights service](http://access.redhat.com/insights).  This role is intended to work on RHEL 6 or RHEL 7, though it will generally work on any yum based system that has access to the insights-client RPM.
 
 Requirements
 ------------
@@ -35,7 +35,7 @@ Example Use
     $ ansible-galaxy install redhataccess.redhat-access-insights-client
     ```
 
-1. Copy the Example Playbook to a file named 'install-insights.yml'.
+1. Copy the Example Playbook above to a file named 'install-insights.yml'.
 
 1. Run the command, replacing 'myhost.example.com' with the name of the
    system where you want to install the insights client.

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,17 +1,22 @@
 ---
 
-- name: Install Red Hat Access Insights Client
-  yum: name={{ item }} state=present
+- name: Install Red Hat Insights Client
+  yum: 
+    name: {{ item }} 
+    state: present
   with_items:
-      - redhat-access-insights
+    - insights-client 
 
-- name: Configure Red Hat Access Insights Client
-  template: src=insights-client.conf.j2 dest=/etc/redhat-access-insights/redhat-access-insights.conf
+- name: Configure Red Hat Insights Client
+  template:
+    src: insights-client.conf.j2
+    dest: /etc/insights-client/insights-client.conf
 
-- stat: path=/etc/redhat-access-insights/.unregistered
+- stat: 
+    path: /etc/insights-client/.unregistered
   register: unreg
 
 # Only register if this system hasn't been registered before
-- name: Register to the Red Hat Access Insights Service
-  command: redhat-access-insights --register creates=/etc/redhat-access-insights/.registered
+- name: Register to the Red Hat Insights Service
+  command: insights-client --register creates=/etc/insights-client/.registered
   when: unreg.stat.exists == false

--- a/templates/insights-client.conf.j2
+++ b/templates/insights-client.conf.j2
@@ -1,5 +1,5 @@
 # {{ ansible_managed }}
-[redhat-access-insights]
+[insights-client]
 # Example options in this file are the defaults
 
 # Change log level, valid options DEBUG, INFO, WARNING, ERROR, CRITICAL. Default DEBUG


### PR DESCRIPTION
Upcoming name change of the client requires us to rename parts of this role to use the new `insights-client` name instead of the old name. This should not be merged to master for use until the full public release and name change takes place.